### PR TITLE
Spotify API - Redirect user for authorization

### DIFF
--- a/assets/js/spotify-api.js
+++ b/assets/js/spotify-api.js
@@ -9,14 +9,13 @@ function redirect(url, queryParams) {
   location.href = url;
 }
 
-function generatePlaylistCover() {
+function generatePlaylistCover(e) {
   const CLIENT_ID = "326af36f3fbd4a0dbcac034ee7216a2d";
   
+  e.preventDefault();
   redirect(`https://accounts.spotify.com/authorize`, queryParams={
     client_id: CLIENT_ID,
     response_type: 'token',
     redirect_uri: 'https://google.com',
   });
 }
-//<script src="spotify-api.js"></script>
-generatePlaylistCover();

--- a/assets/js/spotify-api.js
+++ b/assets/js/spotify-api.js
@@ -1,6 +1,6 @@
 function redirect(url, queryParams) {
   if (queryParams) {
-    let queryString = "?";
+    let queryString = '?';
     for (const key in queryParams) {
       queryString += `${key}=${queryParams[key]}&`
     }
@@ -10,10 +10,10 @@ function redirect(url, queryParams) {
 }
 
 function generatePlaylistCover(e) {
-  const CLIENT_ID = "326af36f3fbd4a0dbcac034ee7216a2d";
+  const CLIENT_ID = '326af36f3fbd4a0dbcac034ee7216a2d';
   
   e.preventDefault();
-  redirect(`https://accounts.spotify.com/authorize`, queryParams={
+  redirect('https://accounts.spotify.com/authorize', queryParams={
     client_id: CLIENT_ID,
     response_type: 'token',
     redirect_uri: 'https://google.com',

--- a/index.html
+++ b/index.html
@@ -6,12 +6,13 @@
     <meta text="utf-8">
     <link href="assets/css/index.css" type="text/css" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css?family=Karla&display=swap" rel="stylesheet">
+    <script src="assets/js/spotify-api.js"></script>
   </head>
   <body>
     <div class="main-content">
       <h1>Generate a picture for your Spotify playlist</h1>
       <p>Paste your Spotify playlist link below</p>
-      <form>
+      <form onsubmit="generatePlaylistCover(event)">
         <input type="text" />
         <input type="submit" />
       </form>

--- a/spotify-api.js
+++ b/spotify-api.js
@@ -1,0 +1,22 @@
+function redirect(url, queryParams) {
+  if (queryParams) {
+    let queryString = "?";
+    for (const key in queryParams) {
+      queryString += `${key}=${queryParams[key]}&`
+    }
+    url += queryString;
+  }
+  location.href = url;
+}
+
+function generatePlaylistCover() {
+  const CLIENT_ID = "326af36f3fbd4a0dbcac034ee7216a2d";
+  
+  redirect(`https://accounts.spotify.com/authorize`, queryParams={
+    client_id: CLIENT_ID,
+    response_type: 'token',
+    redirect_uri: 'https://google.com',
+  });
+}
+//<script src="spotify-api.js"></script>
+generatePlaylistCover();


### PR DESCRIPTION
I created a Spotify App on my Spotify developer account:

![image](https://user-images.githubusercontent.com/3867546/60480733-b1780a00-9c58-11e9-8f85-86d5b8a5d5d1.png)

When you click submit, it will redirect you to an authorization screen (this is required since 2017: https://is.gd/tDU8rB).

After authorizing our Spotify App, it will redirect the browser back to our website but this time with query parameters that have the tokens required to send search requests. I haven't figured out a slick way to redirect to a local HTML file, so right now it just redirects to google.com; will follow-up soon.

Please pull this branch and see if it works on your browser & account :)

